### PR TITLE
chore: remediate postcss and ws CVEs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,21 @@
-# Scheduled dependency version bumps (pull requests).
-# Security PRs for fixable CVEs come from Dependabot Security updates — enable those in GitHub under
-# Organization/repository Settings → Code security → "Dependabot security updates".
+# Dependabot version + security updates for npm.
+# Security PRs also require: Settings → Code security → Dependabot security updates.
 version: 2
 updates:
   - package-ecosystem: npm
     directory: "/"
     schedule:
       interval: weekly
-    open-pull-requests-limit: 15
+    open-pull-requests-limit: 2
     versioning-strategy: increase-if-necessary
+    groups:
+      # All CVE fixes in one PR (instead of one PR per package)
+      npm-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+      # All routine version bumps in one weekly PR
+      npm-dependencies:
+        applies-to: version-updates
+        patterns:
+          - "*"

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "vite-plugin-svgr": "4.3.0",
     "vite-tsconfig-paths": "5.1.4",
     "webextension-polyfill": "0.12.0",
-    "ws": "8.20.0"
+    "ws": "8.20.1"
   },
   "pnpm": {
     "overrides": {
@@ -100,6 +100,7 @@
       "minimatch": "9.0.9",
       "@eslint/eslintrc>minimatch": "3.1.5",
       "picomatch": "4.0.4",
+      "postcss": "8.5.10",
       "rollup": "4.60.1",
       "svgo": "3.3.3",
       "yaml": "1.10.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,7 @@ overrides:
   minimatch: 9.0.9
   '@eslint/eslintrc>minimatch': 3.1.5
   picomatch: 4.0.4
+  postcss: 8.5.10
   rollup: 4.60.1
   svgo: 3.3.3
   yaml: 1.10.3
@@ -106,7 +107,7 @@ importers:
         version: 1.1.4(eslint@9.39.4)(prettier@3.5.3)
       '@cloud-ru/ft-config-stylelint':
         specifier: 3.1.2
-        version: 3.1.2(postcss@8.5.6)(typescript@5.7.3)
+        version: 3.1.2(postcss@8.5.10)(typescript@5.7.3)
       '@cloud-ru/ft-config-vitest':
         specifier: 1.2.2
         version: 1.2.2(@types/node@24.0.10)(terser@5.46.1)(yaml@1.10.3)
@@ -157,7 +158,7 @@ importers:
         version: 26.1.0
       postcss-styled-syntax:
         specifier: 0.7.1
-        version: 0.7.1(postcss@8.5.6)
+        version: 0.7.1(postcss@8.5.10)
       prettier:
         specifier: 3.5.3
         version: 3.5.3
@@ -180,8 +181,8 @@ importers:
         specifier: 0.12.0
         version: 0.12.0
       ws:
-        specifier: 8.20.0
-        version: 8.20.0
+        specifier: 8.20.1
+        version: 8.20.1
 
 packages:
 
@@ -3446,13 +3447,13 @@ packages:
     resolution: {integrity: sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==}
     engines: {node: '>=18.0'}
     peerDependencies:
-      postcss: ^8.4.31
+      postcss: 8.5.10
 
   postcss-scss@4.0.9:
     resolution: {integrity: sha512-AjKOeiwAitL/MXxQW2DliT28EKukvvbEWx3LBmJIRN8KfBGZbRTxNYW0kSqi1COiTZ57nZ9NW06S6ux//N1c9A==}
     engines: {node: '>=12.0'}
     peerDependencies:
-      postcss: ^8.4.29
+      postcss: 8.5.10
 
   postcss-selector-parser@6.1.2:
     resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
@@ -3466,13 +3467,13 @@ packages:
     resolution: {integrity: sha512-V5Iy8JztqXOKnTojdytF8IJ3zDXyVR927XftBPinJa3TnKdChGvGzUNEYlNuDtR+iqpuFkwJMgZdaJarYfGFCg==}
     engines: {node: '>=14.17'}
     peerDependencies:
-      postcss: ^8.5.1
+      postcss: 8.5.10
 
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.5.6:
-    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+  postcss@8.5.10:
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -3898,7 +3899,7 @@ packages:
     resolution: {integrity: sha512-bhaMhh1u5dQqSsf6ri2GVWWQW5iUjBYgcHkh7SgDDn92ijoItC/cfO/W+fpXshgTQWhwFkP1rVcewcv4jaftRg==}
     engines: {node: '>=18.12.0'}
     peerDependencies:
-      postcss: ^8.3.3
+      postcss: 8.5.10
       stylelint: ^16.6.1
     peerDependenciesMeta:
       postcss:
@@ -4345,8 +4346,8 @@ packages:
     resolution: {integrity: sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
-  ws@8.20.0:
-    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+  ws@8.20.1:
+    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -5163,7 +5164,7 @@ snapshots:
       eslint: 9.39.4
       eslint-config-prettier: 10.1.8(eslint@9.39.4)
       eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.1(eslint@9.39.4)(typescript@5.7.3))(eslint@9.39.4))(eslint@9.39.4)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.1(eslint@9.39.4)(typescript@5.7.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.1(eslint@9.39.4)(typescript@5.7.3))(eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.1(eslint@9.39.4)(typescript@5.7.3))(eslint@9.39.4))(eslint@9.39.4))(eslint@9.39.4)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4)
       eslint-plugin-no-only-tests: 3.3.0
       eslint-plugin-prettier: 5.5.5(eslint-config-prettier@10.1.8(eslint@9.39.4))(eslint@9.39.4)(prettier@3.5.3)
@@ -5194,10 +5195,10 @@ snapshots:
       lint-staged: 16.2.7
       prettier: 3.5.3
 
-  '@cloud-ru/ft-config-stylelint@3.1.2(postcss@8.5.6)(typescript@5.7.3)':
+  '@cloud-ru/ft-config-stylelint@3.1.2(postcss@8.5.10)(typescript@5.7.3)':
     dependencies:
       stylelint: 16.6.1(typescript@5.7.3)
-      stylelint-config-recommended-scss: 14.1.0(postcss@8.5.6)(stylelint@16.6.1(typescript@5.7.3))
+      stylelint-config-recommended-scss: 14.1.0(postcss@8.5.10)(stylelint@16.6.1(typescript@5.7.3))
     transitivePeerDependencies:
       - postcss
       - supports-color
@@ -7261,7 +7262,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.1(eslint@9.39.4)(typescript@5.7.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.1(eslint@9.39.4)(typescript@5.7.3))(eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.1(eslint@9.39.4)(typescript@5.7.3))(eslint@9.39.4))(eslint@9.39.4))(eslint@9.39.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -7282,7 +7283,7 @@ snapshots:
       eslint: 9.39.4
       prettier: 2.8.8
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.1(eslint@9.39.4)(typescript@5.7.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.1(eslint@9.39.4)(typescript@5.7.3))(eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.1(eslint@9.39.4)(typescript@5.7.3))(eslint@9.39.4))(eslint@9.39.4))(eslint@9.39.4):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -7933,7 +7934,7 @@ snapshots:
       whatwg-encoding: 3.1.1
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.2.0
-      ws: 8.20.0
+      ws: 8.20.1
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - bufferutil
@@ -8308,13 +8309,13 @@ snapshots:
 
   postcss-resolve-nested-selector@0.1.6: {}
 
-  postcss-safe-parser@7.0.1(postcss@8.5.6):
+  postcss-safe-parser@7.0.1(postcss@8.5.10):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.10
 
-  postcss-scss@4.0.9(postcss@8.5.6):
+  postcss-scss@4.0.9(postcss@8.5.10):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.10
 
   postcss-selector-parser@6.1.2:
     dependencies:
@@ -8326,14 +8327,14 @@ snapshots:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss-styled-syntax@0.7.1(postcss@8.5.6):
+  postcss-styled-syntax@0.7.1(postcss@8.5.10):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.10
       typescript: 5.7.3
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.5.6:
+  postcss@8.5.10:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -8817,14 +8818,14 @@ snapshots:
 
   strip-json-comments@5.0.3: {}
 
-  stylelint-config-recommended-scss@14.1.0(postcss@8.5.6)(stylelint@16.6.1(typescript@5.7.3)):
+  stylelint-config-recommended-scss@14.1.0(postcss@8.5.10)(stylelint@16.6.1(typescript@5.7.3)):
     dependencies:
-      postcss-scss: 4.0.9(postcss@8.5.6)
+      postcss-scss: 4.0.9(postcss@8.5.10)
       stylelint: 16.6.1(typescript@5.7.3)
       stylelint-config-recommended: 14.0.1(stylelint@16.6.1(typescript@5.7.3))
       stylelint-scss: 6.14.0(stylelint@16.6.1(typescript@5.7.3))
     optionalDependencies:
-      postcss: 8.5.6
+      postcss: 8.5.10
 
   stylelint-config-recommended@14.0.1(stylelint@16.6.1(typescript@5.7.3)):
     dependencies:
@@ -8871,9 +8872,9 @@ snapshots:
       micromatch: 4.0.8
       normalize-path: 3.0.0
       picocolors: 1.1.1
-      postcss: 8.5.6
+      postcss: 8.5.10
       postcss-resolve-nested-selector: 0.1.6
-      postcss-safe-parser: 7.0.1(postcss@8.5.6)
+      postcss-safe-parser: 7.0.1(postcss@8.5.10)
       postcss-selector-parser: 6.1.2
       postcss-value-parser: 4.2.0
       resolve-from: 5.0.0
@@ -9204,7 +9205,7 @@ snapshots:
       esbuild: 0.27.2
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.6
+      postcss: 8.5.10
       rollup: 4.60.1
       tinyglobby: 0.2.15
     optionalDependencies:
@@ -9359,7 +9360,7 @@ snapshots:
       imurmurhash: 0.1.4
       signal-exit: 4.1.0
 
-  ws@8.20.0: {}
+  ws@8.20.1: {}
 
   xml-name-validator@5.0.0: {}
 


### PR DESCRIPTION
Коммит готов: **`4be2eaf`** — `chore: remediate postcss and ws CVEs`.

На ветке `sec-scan` сейчас два security-коммита (плюс предыдущая работа по audit). Ниже текст для MR.

---

## Summary

Закрываем Dependabot-алерты по транзитивным и прямым зависимостям, которые Dependabot не мог обновить автоматически (`security_update_not_possible`).

| Пакет | Было | Стало | Как | Severity |
|---|---|---|---|---|
| `@babel/plugin-transform-modules-systemjs` | 7.29.0 | 7.29.4 | `pnpm.overrides` | High |
| `fast-uri` | 3.1.0 | 3.1.2 | `pnpm.overrides` | High |
| `postcss` | 8.5.6 | 8.5.10 | `pnpm.overrides` | Moderate |
| `ws` | 8.20.0 | 8.20.1 | `devDependencies` | Moderate |

Добавлен **`.github/dependabot.yml`** — еженедельные PR с обновлениями npm.

---

## Что делают уязвимости

### `@babel/plugin-transform-modules-systemjs` (High)
При компиляции **специально подготовленного JS** уязвимая версия Babel может сгенерировать выходной код с **выполнением произвольного кода** на машине, где идёт сборка (CI / dev). Риск выше, если в пайплайн попадает недоверенный исходник.

### `fast-uri` (High)
Ошибки парсинга URI (`%2F`, `%2E`, percent-encoded authority) позволяют **обойти path/host-based политики** — приложение может по-разному интерпретировать URL и принять «опасный» адрес за безопасный.

### `postcss` (Moderate)
При сериализации CSS в строку не экранировался `</style>`. Если CSS формируется из недоверенных данных и вставляется в HTML внутри `<style>`, возможен **XSS** — выход из блока стилей и инъекция HTML/скрипта.

### `ws` (Moderate)
В `websocket.close()` при передаче `TypedArray` как reason библиотека могла **утечь неинициализированную память** процесса удалённому клиенту (information disclosure). У нас `ws` используется в dev (reload-сервер, jsdom в тестах) — риск для прод-пользователей минимален, патч всё равно нужен.

---

## Test plan

- [ ] `pnpm install --frozen-lockfile`
- [ ] `pnpm test:unit`
- [ ] `pnpm build`
- [ ] После merge: проверить закрытие алертов Dependabot (#106, #107, #108, #109 и fast-uri)
- [ ] В GitHub Settings включены **Dependabot alerts** и **Dependabot security updates** для автоматических CVE-PR в будущем

---

**Примечание:** ветка `sec-scan` расходится с `origin/sec-scan` (локально 2 коммита, на remote 1). Перед push может понадобиться `git pull --rebase origin sec-scan` или force-push — как принято у вас в команде.