### PR TITLE
docs document cookies permission for Chrome Web Store privacy Update …

### DIFF
--- a/CHROME_WEB_STORE_PRIVACY.md
+++ b/CHROME_WEB_STORE_PRIVACY.md
@@ -4,13 +4,13 @@ Use these values in the Chrome Web Store Developer Dashboard for Cloudhood.
 
 ## Single Purpose
 
-Cloudhood lets developers create local profiles of HTTP request headers and URL filters, then apply those headers to matching browser requests for testing and development.
+Cloudhood lets developers create local profiles of HTTP request headers, request cookies, and URL filters, then apply those values to matching browser requests for testing and development.
 
 ## Permission Justifications
 
 ### storage
 
-Stores user-created header profiles, URL filters, selected profile, pause state, and UI settings locally in the browser.
+Stores user-created header and cookie profiles, URL filters, selected profile, pause state, and UI settings locally in the browser.
 
 ### declarativeNetRequest
 
@@ -24,6 +24,10 @@ Reads extension-managed dynamic rules to keep header modification behavior consi
 
 Reads the active tab URL when tabs are activated or updated so Cloudhood can apply the correct user-created header rules and update the extension badge state for the current page.
 
+### cookies
+
+Sets and removes browser cookies according to user-created cookie rules in the selected profile, so developers can test authenticated requests and session behavior on matching websites. Removes previously applied cookies when the profile changes, rules are disabled, or the extension is paused.
+
 ### Host permissions
 
 Allows user-created header rules to apply to matching websites, including all websites when the user has not limited a profile to specific URL filters.
@@ -36,7 +40,9 @@ Select: No, this extension does not use remote code.
 
 Select no user data categories.
 
-Cloudhood stores user-created profiles, request headers, URL filters, selected profile, pause state, and UI settings locally in the user's browser. This data is not collected by Cloudhood, Cloud.ru, or any developer-operated server.
+Cloudhood stores user-created profiles, request headers, request cookies, URL filters, selected profile, pause state, and UI settings locally in the user's browser. This data is not collected by Cloudhood, Cloud.ru, or any developer-operated server.
+
+Depending on what a user enters into header or cookie values, locally stored extension data can include authentication-related information, such as an `Authorization` header, API token, or session cookie value. Cloudhood does not collect or transmit this data.
 
 Do not select authentication information, web browsing activity, personally identifiable information, health information, financial and payment information, location data, personal communications, or website content unless the extension behavior changes to collect or transmit those categories outside the user's local browser.
 

--- a/PRIVACY_POLICY.md
+++ b/PRIVACY_POLICY.md
@@ -1,8 +1,8 @@
 # Cloudhood Privacy Policy
 
-Last updated: June 17, 2026
+Last updated: June 18, 2026
 
-Cloudhood is a browser extension for developers. It lets users create local profiles of HTTP request headers and URL filters, then apply those headers to matching browser requests for testing and development.
+Cloudhood is a browser extension for developers. It lets users create local profiles of HTTP request headers, request cookies, and URL filters, then apply those values to matching browser requests for testing and development.
 
 ## Data Cloudhood Handles
 
@@ -10,11 +10,12 @@ Cloudhood does not collect user data. It stores the following extension data loc
 
 - User-created request header profiles
 - Header names and values entered by the user
+- Cookie names and values entered by the user
 - URL filters entered by the user
 - The selected profile
 - Pause state and UI settings
 
-Depending on what a user enters into header values, locally stored extension data can include authentication-related information, such as an `Authorization` header, API token, or session-related value. Cloudhood does not collect or transmit this data.
+Depending on what a user enters into header or cookie values, locally stored extension data can include authentication-related information, such as an `Authorization` header, API token, or session cookie value. Cloudhood does not collect or transmit this data.
 
 Cloudhood can read the active tab URL or domain locally when needed to match user-created URL filters and apply the correct request header rules. Cloudhood does not collect, transmit, or store browsing history.
 
@@ -22,14 +23,15 @@ Cloudhood can read the active tab URL or domain locally when needed to match use
 
 Cloudhood uses this data only to provide its core functionality:
 
-- Saving user-created header profiles between browser sessions
+- Saving user-created header and cookie profiles between browser sessions
 - Applying user-created request header rules to matching browser requests
+- Setting and removing browser cookies according to user-created cookie rules on matching websites
 - Showing the current extension state in the popup and browser action badge
 - Importing, exporting, or copying profiles when the user explicitly chooses those actions
 
 ## Local Storage Only
 
-Cloudhood stores extension data in browser local storage. Cloudhood does not collect or send user-created profiles, request headers, URL filters, active tab URLs, or browsing activity to Cloud.ru servers or to any developer-operated server.
+Cloudhood stores extension data in browser local storage. Cloudhood does not collect or send user-created profiles, request headers, request cookies, URL filters, active tab URLs, or browsing activity to Cloud.ru servers or to any developer-operated server.
 
 Cloudhood does not use analytics, advertising, tracking pixels, remote logging, or telemetry for extension user data.
 


### PR DESCRIPTION
…privacy policy and store guidance to cover request cookies usage permission justification and local-only storage